### PR TITLE
https://github.com/uglycustard/buildergenerator/issues/37

### DIFF
--- a/src/main/java/uk/co/buildergenerator/BuilderGenerator.java
+++ b/src/main/java/uk/co/buildergenerator/BuilderGenerator.java
@@ -124,6 +124,7 @@ public class BuilderGenerator {
     private boolean generationGap;
     private String generationGapBaseBuilderPackage;
 	private String generationGapBaseBuilderOutputDirectory;
+    private final Map<Class<?>, String> collectionInitialisationTypes = new HashMap<Class<?>, String>();
 
 	/**
 	 * Construct a <code>BuilderGenerator</code> for an object graph whose graph
@@ -152,6 +153,7 @@ public class BuilderGenerator {
 	    this.rootClass = rootClass;
         this.builderWriter = builderWriter;
         this.fileUtils = fileUtils;
+        this.collectionInitialisationTypes.putAll(CollectionInitialisationTypes.getDefaultMappings());
         setBuilderPackage(deriveDefaultBuilderPackage(rootClass));
         setOutputDirectory(DEFAULT_OUTPUT_DIRECTORY);
     }
@@ -168,7 +170,7 @@ public class BuilderGenerator {
 
         File outputDirectoryFile = fileUtils.newFile(getOutputDirectory());
         fileUtils.createDirectoriesIfNotExists(outputDirectoryFile);
-        BuilderTemplateMapCollector builderTemplateMapCollector = new BuilderTemplateMapCollector(getRootClass(), getBuilderPackage(), propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMapCollector builderTemplateMapCollector = new BuilderTemplateMapCollector(getRootClass(), getBuilderPackage(), propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         List<BuilderTemplateMap> builderTemplateMapList = builderTemplateMapCollector.collectBuilderTemplateMaps();
         
         if (generationGap) {
@@ -421,5 +423,27 @@ public class BuilderGenerator {
 	        addBuilderSuperClass(targetClass, superClass.getName() + "<" + targetClass.getSimpleName() +"Builder>");
 	    }
 	}
+	
+    /**
+	 * Specify the concrete class used to initialise a collection property if it is not initialised.
+	 * <p>
+	 * The defaults are: 
+	 * <br />
+	 * {@link java.util.ArrayList} for a property of type {@link java.util.Collection}
+	 * <br />
+	 * {@link java.util.ArrayList} for a property of type {@link java.util.List}
+	 * <br />
+	 * {@link java.util.HashSet} for a property of type {@link java.util.Set}
+	 * <br />
+	 * {@link java.util.PriorityQueue} for a property of type {@link java.util.Queue}
+	 * 
+	 * @param collectionInterface the collection interface class. For example <code>java.util.Set.class</code>
+	 * @param concreteCollectionClassName the fully qualified class name of the concrete collection class to be instantiated to initialise a property. 
+	 * For example <code>"java.util.LinkedHashSet"</code>
+	 */
+    public void addConcreteCollectionTypeForCollectionInterface(Class<?> collectionInterface, String concreteCollectionClassName) {
+        collectionInitialisationTypes.put(collectionInterface, concreteCollectionClassName);
+    }
+
 
 }

--- a/src/main/java/uk/co/buildergenerator/BuilderGeneratorUtils.java
+++ b/src/main/java/uk/co/buildergenerator/BuilderGeneratorUtils.java
@@ -5,11 +5,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
 
 class BuilderGeneratorUtils {
 
@@ -52,15 +48,9 @@ class BuilderGeneratorUtils {
         return null;
     }
 
-    private static Map<Class<?>, String> collectionInitialisationTypes = new HashMap<Class<?>, String>();
-    static {
-        collectionInitialisationTypes.put(Collection.class, "java.util.ArrayList");
-        collectionInitialisationTypes.put(List.class, "java.util.ArrayList");
-        collectionInitialisationTypes.put(Set.class, "java.util.HashSet");
-        collectionInitialisationTypes.put(Queue.class, "java.util.PriorityQueue");
-    }
+
     
-    String getCollectionTypeWhenCollectionNeedsInitialising(PropertyDescriptor propertyDescriptor) {
+    String getCollectionTypeWhenCollectionNeedsInitialising(PropertyDescriptor propertyDescriptor, Map<Class<?>, String> collectionInitialisationTypes) {
         
         if (isCollection(propertyDescriptor)) {
             if (propertyDescriptor.getPropertyType().isInterface()) {
@@ -72,18 +62,6 @@ class BuilderGeneratorUtils {
         }
         
         return null;
-    }
-    
-    boolean isList(Class<?> type) {
-        return List.class.isAssignableFrom(type);
-    }
-
-    boolean isSet(Class<?> type) {
-        return Set.class.isAssignableFrom(type);
-    }
-
-    boolean isQueue(Class<?> type) {
-        return Queue.class.isAssignableFrom(type);
     }
     
     boolean isMap(Class<?> type) {

--- a/src/main/java/uk/co/buildergenerator/BuilderTemplateMap.java
+++ b/src/main/java/uk/co/buildergenerator/BuilderTemplateMap.java
@@ -1,6 +1,7 @@
 package uk.co.buildergenerator;
 
 import java.util.HashMap;
+import java.util.Map;
 
 class BuilderTemplateMap extends HashMap<String, Object> {
 
@@ -18,13 +19,13 @@ class BuilderTemplateMap extends HashMap<String, Object> {
     static final String GENERATION_GAP_BASE_BUILDER_PACKAGE = "generationGapBaseBuilderPackage";
     static final String BUILDER_INTERFACE_MAP_KEY = "builderInterface";
     
-    BuilderTemplateMap(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore) {
+    BuilderTemplateMap(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore, Map<Class<?>, String> collectionInitialisationTypes) {
         
         put(BUILDER_PACKAGE_MAP_KEY, builderPackage);
         put(TARGET_CLASS_NAME_MAP_KEY, targetClass.getSimpleName());
         put(FULLY_QUALIFIED_TARGET_CLASS_NAME_MAP_KEY, targetClass.getName());
         put(FACTORY_METHOD_PREFIX_MAP_KEY, startsWithVowel(targetClass.getSimpleName()) ? "an" : "a");
-        put(WITH_METHOD_LIST_MAP_KEY, new WithMethodList(targetClass, builderPackage, propertiesToIgnore, classesToIgnore));
+        put(WITH_METHOD_LIST_MAP_KEY, new WithMethodList(targetClass, builderPackage, propertiesToIgnore, classesToIgnore, collectionInitialisationTypes));
         put(GENERATION_GAP_BASE_BUILDER, false);
         put(GENERATION_GAP_BUILDER, false);
         put(SUPER_CLASS_SPECIFIED_MAP_KEY, false);

--- a/src/main/java/uk/co/buildergenerator/BuilderTemplateMapCollector.java
+++ b/src/main/java/uk/co/buildergenerator/BuilderTemplateMapCollector.java
@@ -2,6 +2,7 @@ package uk.co.buildergenerator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 // TODO: TDD me
 class BuilderTemplateMapCollector {
@@ -10,12 +11,14 @@ class BuilderTemplateMapCollector {
     private final String builderPackage;
     private final PropertiesToIgnore propertiesToIgnore;
     private final ClassesToIgnore classesToIgnore;
+    private final Map<Class<?>, String> collectionInitialisationTypes;
 
-    BuilderTemplateMapCollector(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore) {
-        this.targetClass = targetClass;
+    BuilderTemplateMapCollector(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore, Map<Class<?>, String> collectionInitialisationTypes) {
+		this.targetClass = targetClass;
         this.builderPackage = builderPackage;
         this.propertiesToIgnore = propertiesToIgnore;
         this.classesToIgnore = classesToIgnore;
+        this.collectionInitialisationTypes = collectionInitialisationTypes;
     }
     
     List<BuilderTemplateMap> collectBuilderTemplateMaps() {
@@ -33,7 +36,7 @@ class BuilderTemplateMapCollector {
             	return;
             }
 
-            BuilderTemplateMap builderTemplateMap = new BuilderTemplateMap(targetClass, builderPackage, propertiesToIgnore, classesToIgnore);
+            BuilderTemplateMap builderTemplateMap = new BuilderTemplateMap(targetClass, builderPackage, propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
             builderTemplateMapList.add(builderTemplateMap);
             for (WithMethod withMethod : builderTemplateMap.getWithMethodList()) {
                 if (withMethod.isBuilder()) {

--- a/src/main/java/uk/co/buildergenerator/CollectionInitialisationTypes.java
+++ b/src/main/java/uk/co/buildergenerator/CollectionInitialisationTypes.java
@@ -1,0 +1,21 @@
+package uk.co.buildergenerator;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+public final class CollectionInitialisationTypes {
+	
+	public static Map<Class<?>, String> getDefaultMappings() {
+		Map<Class<?>, String> defaults = new LinkedHashMap<Class<?>, String>();
+	    defaults.put(Collection.class, "java.util.ArrayList");
+	    defaults.put(List.class, "java.util.ArrayList");
+	    defaults.put(Set.class, "java.util.HashSet");
+	    defaults.put(Queue.class, "java.util.PriorityQueue");
+		return defaults; 
+	}
+	
+}

--- a/src/main/java/uk/co/buildergenerator/WithMethodFactory.java
+++ b/src/main/java/uk/co/buildergenerator/WithMethodFactory.java
@@ -1,6 +1,7 @@
 package uk.co.buildergenerator;
 
 import java.beans.PropertyDescriptor;
+import java.util.Map;
 
 //TODO: Get rid of this class
 class WithMethodFactory {
@@ -13,8 +14,8 @@ class WithMethodFactory {
     
     private BuilderGeneratorUtils bgu = new BuilderGeneratorUtils();
     
-    WithMethod createWithMethod(PropertyDescriptor propertyDescriptor, Class<?> targetClass, String builderPackage, ClassesToIgnore classesToIgnore) {
-        
+    WithMethod createWithMethod(PropertyDescriptor propertyDescriptor, Class<?> targetClass, String builderPackage, ClassesToIgnore classesToIgnore, Map<Class<?>, String> collectionInitialisationTypes) {
+
         
         String propertyName = bgu.getPropertyName(propertyDescriptor);
         String parameterType = bgu.getParameterType(propertyDescriptor, builderPackage, classesToIgnore);
@@ -23,7 +24,7 @@ class WithMethodFactory {
         boolean collectionNeedsInitialising = bgu.isCollectionNeedsInitialising(targetClass, propertyDescriptor);
         String collectionGetterMethodName = bgu.getCollectionGetterMethodName(propertyDescriptor);
         String collectionSetterMethodName = bgu.getCollectionSetterMethodName(propertyDescriptor);
-        String collectionTypeWhenCollectionNeedsInitialising = bgu.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor);
+        String collectionTypeWhenCollectionNeedsInitialising = bgu.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes);
         String collectionMethodSettingInvocation = bgu.getCollectionMethodSettingInvocation(propertyDescriptor, targetClass);
         boolean builder = bgu.isBuilder(propertyDescriptor, classesToIgnore);
         String builderTargetType = bgu.getBuilderTargetType(propertyDescriptor, classesToIgnore);

--- a/src/main/java/uk/co/buildergenerator/WithMethodList.java
+++ b/src/main/java/uk/co/buildergenerator/WithMethodList.java
@@ -4,6 +4,7 @@ import static uk.co.buildergenerator.WithMethodFactory.getWithMethodFactory;
 
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
+import java.util.Map;
 
 import org.apache.commons.beanutils.PropertyUtils;
 
@@ -13,13 +14,13 @@ class WithMethodList extends ArrayList<WithMethod> {
     
     private static BuilderGeneratorUtils bgu = new BuilderGeneratorUtils();
     
-    WithMethodList(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore) {
+    WithMethodList(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore, Map<Class<?>, String> collectionInitialisationTypes) {
         
         for (PropertyDescriptor propertyDescriptor : PropertyUtils.getPropertyDescriptors(targetClass)) {
             
             try {
                 if (!propertiesToIgnore.isPropertyIgnored(targetClass, propertyDescriptor.getName()) && propertyIsWritable(targetClass, propertyDescriptor)) {
-                    add(getWithMethodFactory().createWithMethod(propertyDescriptor, targetClass, builderPackage, classesToIgnore));
+					add(getWithMethodFactory().createWithMethod(propertyDescriptor, targetClass, builderPackage, classesToIgnore, collectionInitialisationTypes));
                 }
             } catch (RuntimeException e) {
                 throw new RuntimeException(String.format("error generating builder method for property [%s] in class [%s], please log an issue at www.buildergenerator.co.uk", propertyDescriptor.getDisplayName(), targetClass.getName()), e);

--- a/src/test/java/uk/co/buildergenerator/BuilderGeneratorUtilsTest.java
+++ b/src/test/java/uk/co/buildergenerator/BuilderGeneratorUtilsTest.java
@@ -7,8 +7,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -65,42 +69,52 @@ public class BuilderGeneratorUtilsTest {
     public void nullCollectionTypeIsCollection() throws Exception {
         
 	    createPropertyDescriptor("strings", NullCollectionPropertyWithSetCollectionMethod.class);
-	    assertEquals("java.util.ArrayList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+	    collectionInitialisationTypes.put(Collection.class, "java.util.ArrayList");
+		assertEquals("java.util.ArrayList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes ));
     }
 
 	@Test
 	public void nullCollectionTypeIsList() throws Exception {
 
 	    createPropertyDescriptor("strings", NullListPropertyWithSetListMethod.class);
-	    assertEquals("java.util.ArrayList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+	    collectionInitialisationTypes.put(List.class, "java.util.ArrayList");
+	    assertEquals("java.util.ArrayList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
 	}
 
 	@Test
 	public void nullCollectionTypeIsSet() throws Exception {
 
 	    createPropertyDescriptor("strings", NullSetPropertyWithSetSetMethod.class);
-	    assertEquals("java.util.HashSet", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+	    collectionInitialisationTypes.put(Set.class, "java.util.LinkedHashSet");
+	    assertEquals("java.util.LinkedHashSet", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
 	}
 	
     @Test
     public void nullCollectionTypeIsTreeSet() throws Exception {
 
         createPropertyDescriptor("strings", NullTreeSetPropertyWithSetTreeSetMethod.class);
-        assertEquals("java.util.TreeSet", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+        assertEquals("java.util.TreeSet", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
     }
 
     @Test
     public void nullCollectionTypeIsQueue() throws Exception {
 
         createPropertyDescriptor("strings", NullQueuePropertyWithSetQueueMethod.class);
-        assertEquals("java.util.PriorityQueue", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+	    collectionInitialisationTypes.put(Queue.class, "java.util.PriorityQueue");
+        assertEquals("java.util.PriorityQueue", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
     }
     
     @Test
     public void nullCollectionTypeWhenPropertyIsNotACollection() throws Exception {
         
         createPropertyDescriptor("name", House.class);
-        assertEquals(null, testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+        assertEquals(null, testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
         
     }
 
@@ -108,14 +122,16 @@ public class BuilderGeneratorUtilsTest {
     public void nullCollectionTypeIsLinkedList() throws Exception {
 
         createPropertyDescriptor("strings", NullLinkedListPropertyWithSetLinkedListMethod.class);
-        assertEquals("java.util.LinkedList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+        assertEquals("java.util.LinkedList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
     }
 
     @Test
     public void nullCollectionTypeWhenUnrecognisedInterface() throws Exception {
 
         createPropertyDescriptor("strings", NullLinkedListPropertyWithSetLinkedListMethod.class);
-        assertEquals("java.util.LinkedList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+        assertEquals("java.util.LinkedList", testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
     }
 
     @Test
@@ -146,7 +162,8 @@ public class BuilderGeneratorUtilsTest {
         
         createPropertyDescriptor("subList", BeanWithNullSubListInterfaceProperty.class);
         assertFalse(testee.isCollectionNeedsInitialising(BeanWithNullSubListInterfaceProperty.class, propertyDescriptor));
-        assertNull(testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor));
+	    Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
+        assertNull(testee.getCollectionTypeWhenCollectionNeedsInitialising(propertyDescriptor, collectionInitialisationTypes));
         assertEquals("setSubList", testee.getCollectionMethodSettingInvocation(propertyDescriptor, BeanWithNullSubListInterfaceProperty.class));
     }
     

--- a/src/test/java/uk/co/buildergenerator/BuilderTemplateMapTest.java
+++ b/src/test/java/uk/co/buildergenerator/BuilderTemplateMapTest.java
@@ -15,6 +15,10 @@ import static uk.co.buildergenerator.BuilderTemplateMap.SUPER_CLASS_MAP_KEY;
 import static uk.co.buildergenerator.BuilderTemplateMap.SUPER_CLASS_SPECIFIED_MAP_KEY;
 import static uk.co.buildergenerator.BuilderTemplateMap.TARGET_CLASS_NAME_MAP_KEY;
 import static uk.co.buildergenerator.BuilderTemplateMap.WITH_METHOD_LIST_MAP_KEY;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.junit.Test;
 import uk.co.buildergenerator.testmodel.Address;
@@ -27,11 +31,14 @@ public class BuilderTemplateMapTest {
 
     private PropertiesToIgnore propertiesToIgnore = new PropertiesToIgnore();
     private ClassesToIgnore classesToIgnore = new ClassesToIgnore();
+	private Map<Class<?>, String> collectionInitialisationTypes = new LinkedHashMap<Class<?>, String>();
 
+    
+    
     @Test
     public void targetClassName() {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         String expectedTargetClassName = Target.class.getSimpleName();
         assertEquals(expectedTargetClassName, testee.get(TARGET_CLASS_NAME_MAP_KEY));
         assertEquals(expectedTargetClassName, testee.getTargetClassName());
@@ -40,7 +47,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void targetClassFullyQualifiedName() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(House.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(House.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         String expectedTargetClassFullyQualifiedName = House.class.getName();
         assertEquals(expectedTargetClassFullyQualifiedName, testee.get(FULLY_QUALIFIED_TARGET_CLASS_NAME_MAP_KEY));
         assertEquals(expectedTargetClassFullyQualifiedName, testee.getFullyQualifiedTargetClassName());
@@ -49,22 +56,22 @@ public class BuilderTemplateMapTest {
     @Test
     public void factoryMethodPrefix() throws Exception {
 
-        BuilderTemplateMap testee = new BuilderTemplateMap(House.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(House.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         assertEquals("a", testee.get(FACTORY_METHOD_PREFIX_MAP_KEY));
     }
     
     @Test
     public void factoryMethodPrefixForClassStartingWithVowel() throws Exception {
 
-        BuilderTemplateMap testee = new BuilderTemplateMap(Address.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Address.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         assertEquals("an", testee.get(FACTORY_METHOD_PREFIX_MAP_KEY));
     }
     
     @Test
     public void withMethods() throws Exception {
         
-        WithMethodList expectedWithMethodList = new WithMethodList(SubTarget.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
-        BuilderTemplateMap testee = new BuilderTemplateMap(SubTarget.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        WithMethodList expectedWithMethodList = new WithMethodList(SubTarget.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
+        BuilderTemplateMap testee = new BuilderTemplateMap(SubTarget.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         WithMethodList actualWithMethodList = (WithMethodList) testee.get(WITH_METHOD_LIST_MAP_KEY);
         assertTrue(EqualsBuilder.reflectionEquals(expectedWithMethodList, actualWithMethodList));
         assertSame(actualWithMethodList, testee.getWithMethodList());
@@ -74,8 +81,8 @@ public class BuilderTemplateMapTest {
     public void withMethodsWithIgnoreProperties() throws Exception {
         
         propertiesToIgnore.addPropertyToIgnore(BeanWithPropertyToIgnore.class, "propertyToIgnore");
-        WithMethodList expectedWithMethodList = new WithMethodList(BeanWithPropertyToIgnore.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
-        BuilderTemplateMap testee = new BuilderTemplateMap(BeanWithPropertyToIgnore.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        WithMethodList expectedWithMethodList = new WithMethodList(BeanWithPropertyToIgnore.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
+        BuilderTemplateMap testee = new BuilderTemplateMap(BeanWithPropertyToIgnore.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         WithMethodList actualWithMethodList = (WithMethodList) testee.get(WITH_METHOD_LIST_MAP_KEY);
         assertTrue(EqualsBuilder.reflectionEquals(expectedWithMethodList, actualWithMethodList));
         assertSame(actualWithMethodList, testee.getWithMethodList());
@@ -86,7 +93,7 @@ public class BuilderTemplateMapTest {
     public void builderPackage() throws Exception {
 
         String builderPackage = "some.other.package";
-        BuilderTemplateMap testee = new BuilderTemplateMap(Address.class, builderPackage, propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Address.class, builderPackage, propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         assertEquals(builderPackage, testee.get(BUILDER_PACKAGE_MAP_KEY));
         assertEquals(builderPackage, testee.getBuilderPackage());
     }
@@ -94,7 +101,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void notGenerationGapByDefault() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         assertFalse(testee.isGeneratioGapBaseBuilder());
         assertEquals(false, testee.get(GENERATION_GAP_BASE_BUILDER));
         assertFalse(testee.isGeneratioGapBuilder());
@@ -104,7 +111,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void setAsGenerationGapBaseBuilder() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         testee.setAsGenerationGapBaseBuilder();
         assertTrue(testee.isGeneratioGapBaseBuilder());
         assertEquals(true, testee.get(GENERATION_GAP_BASE_BUILDER));
@@ -115,7 +122,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void setGenerationGapBaseBuilderPackage() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         testee.setGenerationGapBaseBuilderPackage("new.package");
         assertEquals("new.package", testee.getGenerationGapBaseBuilderPackage());
         assertEquals("new.package.Builder", testee.getBuilderInterface());
@@ -124,7 +131,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void setAsGenerationGapBuilder() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         testee.setAsGenerationGapBuilder();
         assertFalse(testee.isGeneratioGapBaseBuilder());
         assertEquals(false, testee.get(GENERATION_GAP_BASE_BUILDER));
@@ -135,7 +142,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void setAsGenerationGapBuilderAfterChangingGenerationGapBaseBuilderPackageResetsBuilderInterface() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         assertEquals("uk.co.buildergenerator.Builder", testee.getBuilderInterface());
         testee.setGenerationGapBaseBuilderPackage("new.package");
         assertEquals("new.package.Builder", testee.getBuilderInterface());
@@ -146,7 +153,7 @@ public class BuilderTemplateMapTest {
     @Test
 	public void noSuperClassSpecifiedByDefault() throws Exception {
 		
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
     	assertFalse(testee.isSuperClassSpecified());
     	assertEquals(false, testee.get(SUPER_CLASS_SPECIFIED_MAP_KEY));
     	assertNull(testee.getSuperClass());
@@ -156,7 +163,7 @@ public class BuilderTemplateMapTest {
     @Test
 	public void superClassSpecified() throws Exception {
 		
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         String superClass = "com.example.Something<T>";
         testee.setSuperClass(superClass);
     	assertTrue(testee.isSuperClassSpecified());
@@ -168,7 +175,7 @@ public class BuilderTemplateMapTest {
     @Test
 	public void superClassSpecifiedAsNull() throws Exception {
 		
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         String superClass = null;
         testee.setSuperClass(superClass);
     	assertFalse(testee.isSuperClassSpecified());
@@ -180,7 +187,7 @@ public class BuilderTemplateMapTest {
     @Test
     public void builderInterface() throws Exception {
         
-        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore);
+        BuilderTemplateMap testee = new BuilderTemplateMap(Target.class, "uk.co.buildergenerator", propertiesToIgnore, classesToIgnore, collectionInitialisationTypes);
         String builderInterface = "uk.co.buildergenerator.Builder";
         assertEquals(builderInterface, testee.getBuilderInterface());
         assertEquals(builderInterface, testee.get(BUILDER_INTERFACE_MAP_KEY));

--- a/src/test/java/uk/co/buildergenerator/TestUtils.java
+++ b/src/test/java/uk/co/buildergenerator/TestUtils.java
@@ -12,7 +12,7 @@ public class TestUtils {
         
         try {
             PropertyDescriptor propertyDescriptor = PropertyUtils.getPropertyDescriptor(targetClass.newInstance(), propertyName);
-            return getWithMethodFactory().createWithMethod(propertyDescriptor, targetClass, builderPackage, classesToIgnore);
+            return getWithMethodFactory().createWithMethod(propertyDescriptor, targetClass, builderPackage, classesToIgnore, CollectionInitialisationTypes.getDefaultMappings());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/uk/co/buildergenerator/WithMethodListTest.java
+++ b/src/test/java/uk/co/buildergenerator/WithMethodListTest.java
@@ -23,7 +23,7 @@ public class WithMethodListTest {
     private ClassesToIgnore classesToIgnore = new ClassesToIgnore();
 
     private WithMethodList createTestee(Class<?> targetClass) {
-        return new WithMethodList(targetClass, BUILDER_PACKAGE, propertiesToIgnore, classesToIgnore);
+        return new WithMethodList(targetClass, BUILDER_PACKAGE, propertiesToIgnore, classesToIgnore, CollectionInitialisationTypes.getDefaultMappings());
     }
 
     private WithMethod find(List<WithMethod> withMethodList, String parameterName) {


### PR DESCRIPTION
Hi Matt, I thought I would start with something easy! - If only. The default mapping for concrete collection classes was in BuilderGeneratorUtils and to make it configurable, I pulled it all the way out to BuilderGenerator just like classesToIgnore.

What I have done works but I can't help feeling there is something cleaner to be done. E.g. it feels like a lot of the calls to BuilderGeneratorUtils logic made in WithMethodFactory#createWithMethod should be pushed down WithMethod and the logic removed from BuilderGeneratorUtils .
