### PR TITLE
https://github.com/uglycustard/buildergenerator/issues/42

### DIFF
--- a/src/main/java/uk/co/buildergenerator/BuilderGenerator.java
+++ b/src/main/java/uk/co/buildergenerator/BuilderGenerator.java
@@ -18,36 +18,36 @@ import java.util.Map;
  * output folder chosen by <code>BuilderGenerator</code> call one of the following static utility methods:
  * <p>
  * <code>
- * BuilderGenerator.generateBuilders(MyObjectGraphRoot.class);<br/>
+ * BuilderGenerator.generateBuilders(MyObjectGraphRoot.class);<br>
  * BuilderGenerator.generateBuilders("com.example.MyObjectGraphRoot");
  * </code>
  * <p>
  * To generate builders in either a package and/or output folder other than those chosen by <code>BuilderGenerator</code>:
  * <p>
  * <code>
- * BuilderGenerator bg = new BuilderGenerator(MyObjectGraphRoot.class);<br/>
- * bg.setBuilderPackage("com.example.mypackage");<br/>    
- * bg.setOutputDirectory("/my/output/folder");<br/>    
+ * BuilderGenerator bg = new BuilderGenerator(MyObjectGraphRoot.class);<br>
+ * bg.setBuilderPackage("com.example.mypackage");<br>    
+ * bg.setOutputDirectory("/my/output/folder");<br>    
  * bg.generateBuilders();
  * </code>
  * <p>
  * To ignore properties in a specified class:
  * <p>
  * <code>
- * BuilderGenerator bg = new BuilderGenerator(MyObjectGraphRoot.class);<br/>
- * bg.addPropertyToIgnore(MyObjectGraphRoot.class, "thePropertyToIgnore");<br/>    
+ * BuilderGenerator bg = new BuilderGenerator(MyObjectGraphRoot.class);<br>
+ * bg.addPropertyToIgnore(MyObjectGraphRoot.class, "thePropertyToIgnore");<br>    
  * bg.generateBuilders();
  * </code>
  * <p>
  * To ignore classes in the object graph:
  * <p>
  * <code>
- * BuilderGenerator bg = new BuilderGenerator(MyObjectGraphRoot.class);<br/>
- * bg.addClassToIgnore(MyObjectToIgnore.class);<br/>    
+ * BuilderGenerator bg = new BuilderGenerator(MyObjectGraphRoot.class);<br>
+ * bg.addClassToIgnore(MyObjectToIgnore.class);<br>    
  * bg.generateBuilders();
  * </code>
  * <p>
- * See: <br/>
+ * See: <br>
  * {@link #generateBuilders(Class) generateBuilders}
  * {@link #generateBuilders(String) generateBuilders}
  * {@link #setOutputDirectory(String) setOutputDirectory}
@@ -82,7 +82,7 @@ public class BuilderGenerator {
 	 * Use this utility method when the default builder package and default
 	 * output directory are sufficient.
 	 * </p>
-	 * See: <br/>
+	 * See: <br>
 	 * {@link #setOutputDirectory(String) setOutputDirectory}
 	 * {@link #setBuilderPackage(String) setBuilderPackage}
 	 * 
@@ -102,7 +102,7 @@ public class BuilderGenerator {
 	 * Use this utility method when the default builder package and default
 	 * output directory are sufficient.
 	 * </p>
-	 * See: <br/>
+	 * See: <br>
 	 * {@link #setOutputDirectory(String) setOutputDirectory}
 	 * {@link #setBuilderPackage(String) setBuilderPackage}
 	 * 
@@ -359,14 +359,14 @@ public class BuilderGenerator {
     /**
      * Specify a fully qualified type statement to follow the extends keyword of the generated builder for the target class.
      * 
-     * E.g. if you want the generated builder to be specified as extending "com.example.Foo<T extends com.example.Bar>" then pass that string
-     * as the <code>superClassStatement</code> parameter. 
+     * E.g. if you want the generated builder to be specified as extending "com.example.Foo&lt;T extends com.example.Bar&gt;" then pass that string
+     * as the <code>superClassStatement</code> parameter.
+     * <p>
+     * For more details on this feature see <a href="http://www.buildergenerator.co.uk">www.buildergenerator.co.uk</a>
      * 
      * @param targetClass the target class whose generated builder should extend the given <code>superClassStatement</code>.
      * @param superClassStatement the statement to follow the extends keyword of the generated builder, e.g. com.example.SomeClass
-     * @see <a href="http://www.buildergenerator.co.uk">www.buildergenerator.co.uk</a> for more details on this feature
-     * <br />
-     * {@link #addBuilderSuperClass(Class, Class)}
+     * @see #addBuilderSuperClass(Class, Class)
      */
 	public void addBuilderSuperClass(Class<?> targetClass, String superClassStatement) {
 		builderSuperClass.put(targetClass.getName(), superClassStatement);
@@ -408,11 +408,11 @@ public class BuilderGenerator {
 	 * If the base class you want to extend needs a different extends statement, see 
 	 * {@link #addBuilderSuperClass(Class, String)} which allows you to specify any string to follow the extends keyword.
 	 * <p>
+	 * For more details on this feature see <a href="http://www.buildergenerator.co.uk">www.buildergenerator.co.uk</a>
+	 * <p>
      * @param targetClass the target class whose generated builder should extend the given <code>superClassStatement</code>.
-	 * @param superClass
-     * @see <a href="http://www.buildergenerator.co.uk">www.buildergenerator.co.uk</a> for more details on this feature
-     * <br />
-     * {@link #addBuilderSuperClass(Class, String)}
+	 * @param superClass the super class
+     * @see #addBuilderSuperClass(Class, String)
 	 */
 	public void addBuilderSuperClass(Class<?> targetClass, Class<?> superClass) {
 	    if (generationGap) {

--- a/src/main/java/uk/co/buildergenerator/WithMethodList.java
+++ b/src/main/java/uk/co/buildergenerator/WithMethodList.java
@@ -4,6 +4,8 @@ import static uk.co.buildergenerator.WithMethodFactory.getWithMethodFactory;
 
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import org.apache.commons.beanutils.PropertyUtils;
 
@@ -12,10 +14,19 @@ class WithMethodList extends ArrayList<WithMethod> {
     private static final long serialVersionUID = 1L;
     
     private static BuilderGeneratorUtils bgu = new BuilderGeneratorUtils();
+
+	private static final Comparator<PropertyDescriptor> ORDER_BY_NAME_COMPARATOR = new Comparator<PropertyDescriptor>() {
+		@Override
+		public int compare(PropertyDescriptor o1, PropertyDescriptor o2) {
+			return o1.getName().compareTo(o2.getName());
+		}
+	};
     
     WithMethodList(Class<?> targetClass, String builderPackage, PropertiesToIgnore propertiesToIgnore, ClassesToIgnore classesToIgnore) {
         
-        for (PropertyDescriptor propertyDescriptor : PropertyUtils.getPropertyDescriptors(targetClass)) {
+        PropertyDescriptor[] properyDescriptors = PropertyUtils.getPropertyDescriptors(targetClass);
+        Arrays.sort(properyDescriptors, ORDER_BY_NAME_COMPARATOR);
+		for (PropertyDescriptor propertyDescriptor : properyDescriptors) {
             
             try {
                 if (!propertiesToIgnore.isPropertyIgnored(targetClass, propertyDescriptor.getName()) && propertyIsWritable(targetClass, propertyDescriptor)) {

--- a/src/test/java/uk/co/buildergenerator/integrationtest/BuilderGeneratorIT.java
+++ b/src/test/java/uk/co/buildergenerator/integrationtest/BuilderGeneratorIT.java
@@ -3,6 +3,7 @@ package uk.co.buildergenerator.integrationtest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -12,7 +13,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.net.URL;
+
+import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
+
 import uk.co.buildergenerator.BuilderGenerator;
 import uk.co.buildergenerator.FileUtils;
 import uk.co.buildergenerator.testmodel.Address;
@@ -79,8 +83,12 @@ public class BuilderGeneratorIT {
         StringBuilder sb = new StringBuilder();
         String line = null;
         while ((line = r.readLine()) != null) {
-            line = line.trim();
-            sb.append(line);
+        	// throw away trailing white space, but not leading for test failure readability
+            line = StringUtils.stripEnd(line, null);
+        	// throw away blank lines
+            if (line.length() > 0) {
+                sb.append(line + "\n");
+            }
         }
         
         return sb.toString();
@@ -91,6 +99,7 @@ public class BuilderGeneratorIT {
         String expected = readFile(expectedBuilderFilename);
         String actual = readFile(generatedBuilderFilename);
         assertEquals(expected, actual);
+        
     }
     
     private BuilderGenerator createBuilderGenerator(Class<?> root, String builderPackage, String outputDirectory) {

--- a/src/test/resources/integrationtest/expectedbuilder/AddressBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/AddressBuilder.java
@@ -9,9 +9,7 @@ public class AddressBuilder implements integrationtest.generatedbuilder.Builder<
 
     private uk.co.buildergenerator.testmodel.Address target = new uk.co.buildergenerator.testmodel.Address();
 
-    public AddressBuilder() {
-
-    }
+    public AddressBuilder() {}
 
     public AddressBuilder withHouse(integrationtest.generatedbuilder.Builder<uk.co.buildergenerator.testmodel.House> house) {
 

--- a/src/test/resources/integrationtest/expectedbuilder/BeanWithAnInterfaceCollectionPropertyBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/BeanWithAnInterfaceCollectionPropertyBuilder.java
@@ -10,14 +10,6 @@ public class BeanWithAnInterfaceCollectionPropertyBuilder implements integration
     
     public BeanWithAnInterfaceCollectionPropertyBuilder() {}
     
-    public BeanWithAnInterfaceCollectionPropertyBuilder withAnInterfacesNullList(uk.co.buildergenerator.testmodel.AnInterface anInterfacesNullList) {
-        if (getTarget().getAnInterfacesNullList() == null) {
-            getTarget().setAnInterfacesNullList(new java.util.ArrayList<uk.co.buildergenerator.testmodel.AnInterface>());
-        }        
-        getTarget().getAnInterfacesNullList().add(anInterfacesNullList);
-        return this;
-    }
-    
     public BeanWithAnInterfaceCollectionPropertyBuilder withAnInterfacesArrayList(uk.co.buildergenerator.testmodel.AnInterface anInterfacesArrayList) {
         getTarget().getAnInterfacesArrayList().add(anInterfacesArrayList);
         return this;
@@ -25,6 +17,14 @@ public class BeanWithAnInterfaceCollectionPropertyBuilder implements integration
     
     public BeanWithAnInterfaceCollectionPropertyBuilder withAnInterfacesArrayListWithAddMethod(uk.co.buildergenerator.testmodel.AnInterface anInterfacesArrayListWithAddMethod) {
         getTarget().addAnInterfacesArrayListWithAddMethod(anInterfacesArrayListWithAddMethod);
+        return this;
+    }
+    
+    public BeanWithAnInterfaceCollectionPropertyBuilder withAnInterfacesNullList(uk.co.buildergenerator.testmodel.AnInterface anInterfacesNullList) {
+        if (getTarget().getAnInterfacesNullList() == null) {
+            getTarget().setAnInterfacesNullList(new java.util.ArrayList<uk.co.buildergenerator.testmodel.AnInterface>());
+        }        
+        getTarget().getAnInterfacesNullList().add(anInterfacesNullList);
         return this;
     }
     

--- a/src/test/resources/integrationtest/expectedbuilder/BeanWithChildBeanToBeIgnoredBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/BeanWithChildBeanToBeIgnoredBuilder.java
@@ -10,13 +10,13 @@ public class BeanWithChildBeanToBeIgnoredBuilder implements integrationtest.gene
     
     public BeanWithChildBeanToBeIgnoredBuilder() {}
     
-    public BeanWithChildBeanToBeIgnoredBuilder withSomeProperty(java.lang.String someProperty) {
-        getTarget().setSomeProperty(someProperty);
+    public BeanWithChildBeanToBeIgnoredBuilder withBeanToBeIgnored(uk.co.buildergenerator.testmodel.BeanToBeIgnored beanToBeIgnored) {
+        getTarget().setBeanToBeIgnored(beanToBeIgnored);
         return this;
     }
     
-    public BeanWithChildBeanToBeIgnoredBuilder withBeanToBeIgnored(uk.co.buildergenerator.testmodel.BeanToBeIgnored beanToBeIgnored) {
-        getTarget().setBeanToBeIgnored(beanToBeIgnored);
+    public BeanWithChildBeanToBeIgnoredBuilder withSomeProperty(java.lang.String someProperty) {
+        getTarget().setSomeProperty(someProperty);
         return this;
     }
     

--- a/src/test/resources/integrationtest/expectedbuilder/BeanWithJodaTimeBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/BeanWithJodaTimeBuilder.java
@@ -15,13 +15,13 @@ public class BeanWithJodaTimeBuilder implements integrationtest.generatedbuilder
         return this;
     }
     
-    public BeanWithJodaTimeBuilder withLocalTime(org.joda.time.LocalTime localTime) {
-        getTarget().setLocalTime(localTime);
-        return this;
-    }
-    
     public BeanWithJodaTimeBuilder withLocalDate(org.joda.time.LocalDate localDate) {
         getTarget().setLocalDate(localDate);
+        return this;
+    }
+
+    public BeanWithJodaTimeBuilder withLocalTime(org.joda.time.LocalTime localTime) {
+        getTarget().setLocalTime(localTime);
         return this;
     }
     

--- a/src/test/resources/integrationtest/expectedbuilder/BeanWithMapPropertyBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/BeanWithMapPropertyBuilder.java
@@ -7,11 +7,10 @@ public class BeanWithMapPropertyBuilder implements integrationtest.generatedbuil
 
     private uk.co.buildergenerator.testmodel.BeanWithMapProperty target = new uk.co.buildergenerator.testmodel.BeanWithMapProperty();
 
-    public BeanWithMapPropertyBuilder() {
-    }
+    public BeanWithMapPropertyBuilder() {}
 
-    public BeanWithMapPropertyBuilder withMapOfStrings(java.util.Map<java.lang.String, java.lang.String> mapOfStrings) {
-        getTarget().setMapOfStrings(mapOfStrings);
+    public BeanWithMapPropertyBuilder withMapOfAnything(java.util.Map mapOfAnything) {
+        getTarget().setMapOfAnything(mapOfAnything);
         return this;
     }
 
@@ -20,8 +19,8 @@ public class BeanWithMapPropertyBuilder implements integrationtest.generatedbuil
         return this;
     }
 
-    public BeanWithMapPropertyBuilder withMapOfAnything(java.util.Map mapOfAnything) {
-        getTarget().setMapOfAnything(mapOfAnything);
+    public BeanWithMapPropertyBuilder withMapOfStrings(java.util.Map<java.lang.String, java.lang.String> mapOfStrings) {
+        getTarget().setMapOfStrings(mapOfStrings);
         return this;
     }
 

--- a/src/test/resources/integrationtest/expectedbuilder/BeanWithMultiDimensionalArrayOfPrimitivesBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/BeanWithMultiDimensionalArrayOfPrimitivesBuilder.java
@@ -10,6 +10,11 @@ public class BeanWithMultiDimensionalArrayOfPrimitivesBuilder implements integra
     
     public BeanWithMultiDimensionalArrayOfPrimitivesBuilder() {}
     
+    public BeanWithMultiDimensionalArrayOfPrimitivesBuilder withFourDimensionalCharArray(char[][][][] fourDimensionalCharArray) {
+        getTarget().setFourDimensionalCharArray(fourDimensionalCharArray);
+        return this;
+    }
+    
     public BeanWithMultiDimensionalArrayOfPrimitivesBuilder withThreeDimenstionalIntArray(int[][][] threeDimenstionalIntArray) {
         getTarget().setThreeDimenstionalIntArray(threeDimenstionalIntArray);
         return this;
@@ -17,11 +22,6 @@ public class BeanWithMultiDimensionalArrayOfPrimitivesBuilder implements integra
     
     public BeanWithMultiDimensionalArrayOfPrimitivesBuilder withTwoDimensionalBooleanArray(boolean[][] twoDimensionalBooleanArray) {
         getTarget().setTwoDimensionalBooleanArray(twoDimensionalBooleanArray);
-        return this;
-    }
-    
-    public BeanWithMultiDimensionalArrayOfPrimitivesBuilder withFourDimensionalCharArray(char[][][][] fourDimensionalCharArray) {
-        getTarget().setFourDimensionalCharArray(fourDimensionalCharArray);
         return this;
     }
     

--- a/src/test/resources/integrationtest/expectedbuilder/BeanWithNonGenericCollectionsBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/BeanWithNonGenericCollectionsBuilder.java
@@ -10,16 +10,16 @@ public class BeanWithNonGenericCollectionsBuilder implements integrationtest.gen
     
     public BeanWithNonGenericCollectionsBuilder() {}
     
+    public BeanWithNonGenericCollectionsBuilder withBean(java.lang.Object bean) {
+        getTarget().addBean(bean);
+        return this;
+    }
+
     public BeanWithNonGenericCollectionsBuilder withStuff(java.lang.Object stuff) {
         if (getTarget().getStuff() == null) {
             getTarget().setStuff(new java.util.HashSet<java.lang.Object>());
         }        
         getTarget().getStuff().add(stuff);
-        return this;
-    }
-    
-    public BeanWithNonGenericCollectionsBuilder withBean(java.lang.Object bean) {
-        getTarget().addBean(bean);
         return this;
     }
     

--- a/src/test/resources/integrationtest/expectedbuilder/RootBuilder.java
+++ b/src/test/resources/integrationtest/expectedbuilder/RootBuilder.java
@@ -10,6 +10,11 @@ public class RootBuilder implements integrationtest.generatedbuilder.Builder<uk.
     
     public RootBuilder() {}
     
+    public RootBuilder withNodeOne(integrationtest.generatedbuilder.Builder<uk.co.buildergenerator.testmodel.NodeOne> nodeOne) {
+        getTarget().setNodeOne(nodeOne.build());
+        return this;
+    }
+    
     public RootBuilder withNodeTwo(integrationtest.generatedbuilder.Builder<uk.co.buildergenerator.testmodel.NodeTwo> nodeTwo) {
         getTarget().setNodeTwo(nodeTwo.build());
         return this;
@@ -17,11 +22,6 @@ public class RootBuilder implements integrationtest.generatedbuilder.Builder<uk.
     
     public RootBuilder withRootString(java.lang.String rootString) {
         getTarget().setRootString(rootString);
-        return this;
-    }
-    
-    public RootBuilder withNodeOne(integrationtest.generatedbuilder.Builder<uk.co.buildergenerator.testmodel.NodeOne> nodeOne) {
-        getTarget().setNodeOne(nodeOne.build());
         return this;
     }
     


### PR DESCRIPTION
This change allows Builder Generator to be built using maven under Java 7 or Java 8. 
It makes the order of the generated methods determinate based on the alphabetic ordering of the property names.
It fixes some javadoc formatting issues that are stricter under Java 8
(Also this change makes the BuilderGeneratorIT more friendly on failure, by switching to a multiline string for the expected and actual files. This makes failures much easier to diagnose visually in the Junit test runner.)
